### PR TITLE
fix Python reference

### DIFF
--- a/discussion/tree.ipynb
+++ b/discussion/tree.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "__Binary search trees have to satisfy one rule.__ The value of any given node has to be larger than the left child and its descendants, and smaller than the right child and its descendants. If you check the picture, you will see this rule is observed: e.g. all nodes to the left of the root are smaller than 8, and all nodes to the right are bigger. Furthermore, this is true for every node, not just the root. \n",
     "\n",
-    "To look for a value inside the tree, you start at the root and go either left or right. At each step, you eliminate roughly half of the possibilities, provided that the tree is balanced (that is, not too lopsided). The point is that this is very fast, and in a specific technical sense it is provably the fastest possible way to locate a value in sorted data. (Take PIC 10B if you want to hear about time complexity of algorithms.) For this reason, many data structures like sets and dictionaries are just binary search trees under the hood. When you query one of these structures to retrieve a value, Python is implicitly using a binary search tree to find what you're looking for. "
+    "To look for a value inside the tree, you start at the root and go either left or right. At each step, you eliminate roughly half of the possibilities, provided that the tree is balanced (that is, not too lopsided). The point is that this is very fast, and in a specific technical sense it is provably the fastest possible way to locate a value in sorted data. (Take PIC 10B if you want to hear about time complexity of algorithms.) For this reason, many data structures use binary search trees under the hood."
    ]
   },
   {


### PR DESCRIPTION
It's not really correct to say that Python dictionaries use binary search trees: the most common Python distributions use hash tables, although I'm not sure if this is strictly required by the language.  This pull request removes the statement that "Python uses binary search trees under the hood", although it doesn't replace it with anything particularly interesting.