### PR TITLE
better prime examples

### DIFF
--- a/discussion/primes.ipynb
+++ b/discussion/primes.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "## §1. Test Primes\n",
     "\n",
-    "First, write a function called `is_prime(n)` that tests whether a integer `n` is prime. Do so by checking whether `i` divides `n` for every positive integer `i < n`. \n",
+    "First, write a function called `is_prime(n)` that tests whether a integer `n` is prime. Do so by checking whether `i` divides `n` for every positive integer `i < n`. Remember that `0` and `1` are not prime.\n",
     "\n",
     "**Note:** `i` divides `n` iff `n % i == 0`.\n",
     "\n",
@@ -76,8 +76,8 @@
     "Jupyter comes with a special \"magic macro\" that lets you compare the execution speed of your functions. To use it, add `%timeit` (\"time it\") in front of your function call. Write and run the following two lines: \n",
     "\n",
     "```python\n",
-    "%timeit is_prime(9977)\n",
-    "%timeit fast_is_prime(9977)\n",
+    "%timeit is_prime(9973)\n",
+    "%timeit fast_is_prime(9973)\n",
     "```\n",
     "\n",
     "You'll see some summary statistics based on a large number of repetitions of your function. How much faster is `fast_is_prime` than `is_prime`? "
@@ -89,14 +89,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# try testing 9977\n"
+    "# try testing 9973\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now test `n = 1000000`. How much faster is your implementation of `fast_is_prime()`? \n",
+    "Now test `n = 1000003`. How much faster is your implementation of `fast_is_prime()`? \n",
     "\n",
     "**Note:** What is $\\sqrt{1,000,000}$?"
    ]
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# try testing 1000000\n"
+    "# try testing 1000003\n"
    ]
   },
   {
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now use `%timeit` to compare the speed of your two implementations, and comment on the result. "
+    "Now use `%timeit` to compare the speed of your two implementations, and comment on the result.  Check the time for both small and large numbers of `n`."
    ]
   },
   {


### PR DESCRIPTION
This addresses three concerns with this worksheet:

1) 0 and 1 are not prime, and some people might not know that at the beginning.
2) fast_is_prime is more than likely slower than is_prime when tested on composite numbers, because the student solution more than likely breaks out of the loop when a factor is found
3) primes_up_to_2 is absolutely slower than primes_up_to, although that may be intentional.  The number of primes less than n is pretty much always larger than sqrt(n).  I think you do get some speed benefit for low n, although I'm not sure why.